### PR TITLE
Link against crt* to support C++ global constructor / destructor

### DIFF
--- a/gcc/config/redox.h
+++ b/gcc/config/redox.h
@@ -5,10 +5,10 @@
 #define LIB_SPEC "-lc"
 
 #undef STARTFILE_SPEC
-#define STARTFILE_SPEC "crt0.o%s"
+#define STARTFILE_SPEC "crt0.o%s crti.o%s crtbegin.o%s"
 
 #undef ENDFILE_SPEC
-#define ENDFILE_SPEC   ""
+#define ENDFILE_SPEC   "crtend.o%s crtn.o%s"
 
 #undef  NO_IMPLICIT_EXTERN_C
 #define NO_IMPLICIT_EXTERN_C 1

--- a/libgcc/config.host
+++ b/libgcc/config.host
@@ -637,11 +637,11 @@ x86_64-*-kfreebsd*-gnu)
 	tm_file="${tm_file} i386/elf-lib.h"
 	;;
 i[34567]86-*-redox*)
-	extra_parts="$extra_parts crtbegin.o crtend.o"
+	extra_parts="$extra_parts crtbegin.o crtend.o crti.o crtn.o"
 	tmake_file="$tmake_file i386/t-crtstuff t-crtstuff-pic t-libgcc-pic"
 	;;
 x86_64-*-redox*)
-	extra_parts="$extra_parts crtbegin.o crtend.o"
+	extra_parts="$extra_parts crtbegin.o crtend.o crti.o crtn.o"
 	tmake_file="$tmake_file i386/t-crtstuff t-crtstuff-pic t-libgcc-pic"
 	;;
 i[34567]86-pc-msdosdjgpp*)


### PR DESCRIPTION
This also requires changes to crt0 in newlib.